### PR TITLE
Fix typo in copy  and assignment methods

### DIFF
--- a/C-11/MemoryPool.tcc
+++ b/C-11/MemoryPool.tcc
@@ -64,7 +64,7 @@ noexcept
   memoryPool.currentBlock_ = nullptr;
   currentSlot_ = memoryPool.currentSlot_;
   lastSlot_ = memoryPool.lastSlot_;
-  freeSlots_ = memoryPool.freeSlots;
+  freeSlots_ = memoryPool.freeSlots_;
 }
 
 
@@ -87,7 +87,7 @@ noexcept
     std::swap(currentBlock_, memoryPool.currentBlock_);
     currentSlot_ = memoryPool.currentSlot_;
     lastSlot_ = memoryPool.lastSlot_;
-    freeSlots_ = memoryPool.freeSlots;
+    freeSlots_ = memoryPool.freeSlots_;
   }
   return *this;
 }


### PR DESCRIPTION
Fixes variable name typo.  